### PR TITLE
Change minecraft:grass --> minecraft:short_grass for 1.20.3

### DIFF
--- a/features/vegetation/grass.yml
+++ b/features/vegetation/grass.yml
@@ -26,5 +26,5 @@ structures:
   distribution:
     type: WHITE_NOISE
   structures:
-    - BLOCK:minecraft:grass: 6
+    - BLOCK:minecraft:short_grass: 6
     - tall_grass: 1

--- a/features/vegetation/grass_caves.yml
+++ b/features/vegetation/grass_caves.yml
@@ -26,5 +26,5 @@ structures:
   distribution:
     type: WHITE_NOISE
   structures:
-    - BLOCK:minecraft:grass: 6
+    - BLOCK:minecraft:short_grass: 6
     - tall_grass: 1

--- a/features/vegetation/tall_grass.yml
+++ b/features/vegetation/tall_grass.yml
@@ -39,4 +39,4 @@ structures:
     type: WHITE_NOISE
   structures:
     - tall_grass: 8
-    - BLOCK:minecraft:grass: 1
+    - BLOCK:minecraft:short_grass: 1


### PR DESCRIPTION
This will properly fix compatibility for 1.20.3+. 
Although the pack works as is on 1.20.3+, in the console Terra complains about translating minecraft:grass to minecraft:short_grass. This pull request will fix those errors (hopefully).